### PR TITLE
Properly updates path definitions

### DIFF
--- a/.changeset/clever-garlics-worry.md
+++ b/.changeset/clever-garlics-worry.md
@@ -1,0 +1,5 @@
+---
+'@wanews/nx-typescript-project-references': patch
+---
+
+Fixed method of updating tsconfig.base paths

--- a/libs/typescript-project-references/src/generators/library/generator.spec.ts
+++ b/libs/typescript-project-references/src/generators/library/generator.spec.ts
@@ -1,20 +1,21 @@
-import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing';
-import { Tree, readProjectConfiguration } from '@nrwl/devkit';
+import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing'
+import { Tree, readProjectConfiguration } from '@nrwl/devkit'
 
-import generator from './generator';
-import { LibraryGeneratorSchema } from './schema';
+import generator from './generator'
+import { LibraryGeneratorSchema } from './schema'
 
 describe('library generator', () => {
-  let appTree: Tree;
-  const options: LibraryGeneratorSchema = { name: 'test' };
+    let appTree: Tree
+    const options: LibraryGeneratorSchema = { name: 'test' }
 
-  beforeEach(() => {
-    appTree = createTreeWithEmptyWorkspace();
-  });
+    beforeEach(() => {
+        appTree = createTreeWithEmptyWorkspace()
+    })
 
-  it('should run successfully', async () => {
-    await generator(appTree, options);
-    const config = readProjectConfiguration(appTree, 'test');
-    expect(config).toBeDefined();
-  })
-});
+    it('should run successfully', async () => {
+        await generator(appTree, options)
+        const config = readProjectConfiguration(appTree, 'test')
+        console.log(config)
+        expect(config).toBeDefined()
+    })
+})

--- a/libs/typescript-project-references/src/generators/library/generator.ts
+++ b/libs/typescript-project-references/src/generators/library/generator.ts
@@ -82,11 +82,13 @@ export default async function (host: Tree, options: LibraryGeneratorSchema) {
     })
     addFiles(host, normalizedOptions)
     updateJson(host, 'tsconfig.base.json', (value) => {
-        value.paths.push({
+        const oldPaths = value.paths
+
+        return {
+            ...oldPaths,
             [options.packageName ||
             options.name]: `${normalizedOptions.projectRoot}/src/index.ts`,
-        })
-        return value
+        }
     })
     await formatFiles(host)
 }


### PR DESCRIPTION
## What this does
uses the correct method of updating path info for typescript-project-references generator 🤡 