### PR TITLE
Bugfix/prevent tsconfig base overwrite

### DIFF
--- a/.changeset/fifty-forks-begin.md
+++ b/.changeset/fifty-forks-begin.md
@@ -1,0 +1,5 @@
+---
+'@wanews/nx-typescript-project-references': patch
+---
+
+Prevents tsconfig.base being overwritten

--- a/libs/typescript-project-references/src/generators/library/generator.ts
+++ b/libs/typescript-project-references/src/generators/library/generator.ts
@@ -82,13 +82,16 @@ export default async function (host: Tree, options: LibraryGeneratorSchema) {
     })
     addFiles(host, normalizedOptions)
     updateJson(host, 'tsconfig.base.json', (value) => {
-        const oldPaths = value.paths
+        const existingPaths = value.compilerOptions.paths
 
-        return {
-            ...oldPaths,
-            [options.packageName ||
-            options.name]: `${normalizedOptions.projectRoot}/src/index.ts`,
+        value.compilerOptions.paths = {
+            ...existingPaths,
+            [options.packageName || options.name]: [
+                `${normalizedOptions.projectRoot}/src/index.ts`,
+            ],
         }
+
+        return value
     })
     await formatFiles(host)
 }


### PR DESCRIPTION
#12 accidentally replaced the entire contents of tsconfig.base.json with a single path reference to the newly generated project.

This fixes that. 🤡 🤡 