### PR TITLE
[FIX] nx-esbuild:build fails on success

### DIFF
--- a/libs/nx-esbuild/src/executors/build/executor.ts
+++ b/libs/nx-esbuild/src/executors/build/executor.ts
@@ -1,7 +1,7 @@
-import { BuildExecutorSchema } from './schema'
 import { ExecutorContext, readJson } from '@nrwl/devkit'
 import { FsTree } from '@nrwl/tao/src/shared/tree'
 import { build } from 'esbuild'
+import { BuildExecutorSchema } from './schema'
 
 export default async function runExecutor(
     options: BuildExecutorSchema,
@@ -45,6 +45,6 @@ export default async function runExecutor(
     })
 
     return {
-        success: result.errors.length === 0,
+        success: !(result.errors && result.errors.length !== 0),
     }
 }

--- a/libs/typescript-project-references/src/generators/library/generator.spec.ts
+++ b/libs/typescript-project-references/src/generators/library/generator.spec.ts
@@ -1,6 +1,5 @@
+import { readProjectConfiguration, Tree } from '@nrwl/devkit'
 import { createTreeWithEmptyWorkspace } from '@nrwl/devkit/testing'
-import { Tree, readProjectConfiguration } from '@nrwl/devkit'
-
 import generator from './generator'
 import { LibraryGeneratorSchema } from './schema'
 
@@ -15,7 +14,6 @@ describe('library generator', () => {
     it('should run successfully', async () => {
         await generator(appTree, options)
         const config = readProjectConfiguration(appTree, 'test')
-        console.log(config)
         expect(config).toBeDefined()
     })
 })


### PR DESCRIPTION
Successful builds are reporting as failures. 
- Fix the error check in nx-esbuild executor to check for the presence of the errors array in the results object

**Before:**
<img width="522" alt="Screen Shot 2021-05-20 at 10 15 55 am" src="https://user-images.githubusercontent.com/311369/118909260-58511680-b955-11eb-9c9a-88af97e71651.png">

**After**
<img width="525" alt="Screen Shot 2021-05-20 at 10 16 03 am" src="https://user-images.githubusercontent.com/311369/118909274-6010bb00-b955-11eb-91f6-0c79ab4eb0a5.png">

