### PR TITLE
ignore node_modules when linting

### DIFF
--- a/libs/nx-esbuild/src/generators/node/files/.eslintrc.json__template__
+++ b/libs/nx-esbuild/src/generators/node/files/.eslintrc.json__template__
@@ -1,6 +1,9 @@
 {
   "extends": ["<%= offsetFromRoot %>.eslintrc.json"],
-  "ignorePatterns": ["!**/*"],
+  "ignorePatterns": [
+    "!**/*",
+    "node_modules/**"
+  ],
   "overrides": [
     {
       "files": ["*.ts", "*.tsx"],


### PR DESCRIPTION
Currently seeing linting errors in files in node_modules. This should prevent it from occurring in new projects.