### PR TITLE
Fix `[object Object]` in console output for additionalBuildTargets

### DIFF
--- a/.changeset/chatty-shoes-shake.md
+++ b/.changeset/chatty-shoes-shake.md
@@ -1,0 +1,5 @@
+---
+'@wanews/nx-pulumi': patch
+---
+
+fix a bug affecting console output

--- a/libs/pulumi/src/executors/up/executor.ts
+++ b/libs/pulumi/src/executors/up/executor.ts
@@ -43,7 +43,7 @@ export default async function runUpExecutor(
                 additionalBuildTarget.target
             }${
                 additionalBuildTarget.configuration
-                    ? `:${additionalBuildTarget}`
+                    ? `:${additionalBuildTarget.configuration}`
                     : ''
             }`,
         )


### PR DESCRIPTION
Currently, additionalBuildTargets prints the wrong output when configuration is set:

```
nx run common-infrastructure:package:[object Object]
```