### PR TITLE
allow overriding the infrastructure project name

### DIFF
--- a/.changeset/honest-moles-carry.md
+++ b/.changeset/honest-moles-carry.md
@@ -1,0 +1,5 @@
+---
+'@wanews/nx-pulumi': minor
+---
+
+allow overriding infrastructure project name in workspace.json

--- a/libs/pulumi/src/executors/up/executor.ts
+++ b/libs/pulumi/src/executors/up/executor.ts
@@ -12,8 +12,14 @@ export default async function runUpExecutor(
     if (!context.projectName) {
         throw new Error('No projectName')
     }
+
+    const infrastructureProject = options.infrastructureProject
+        ?? `${context.projectName}-infrastructure`
+
     const infrastructureRoot =
-        context.workspace.projects[`${context.projectName}-infrastructure`].root
+        context.workspace.projects[
+            infrastructureProject
+        ].root
 
     console.log(
         `> nx run ${options.targetProjectName}:${

--- a/libs/pulumi/src/executors/up/schema.d.ts
+++ b/libs/pulumi/src/executors/up/schema.d.ts
@@ -7,4 +7,5 @@ export interface BuildExecutorSchema {
         target: string
         configuration?: string
     }>
+    infrastructureProject?: string
 }


### PR DESCRIPTION
Currently, the infrastructure project must be named `${context.projectName}-infrastructure`, and it's not possible to use a different name

Let's allow the infrastructure project name to be overridden in workspace.json