### PR TITLE
add support for the yarn package manager

### DIFF
--- a/.changeset/heavy-lions-invite.md
+++ b/.changeset/heavy-lions-invite.md
@@ -1,0 +1,5 @@
+---
+'@wanews/nx-esbuild': minor
+---
+
+add support for the yarn package manager


### PR DESCRIPTION
Mostly copypasted from pnpm support.

The only difference is that yarn doesn't have a make-dedicated-lockfile command, so instead we just use the lockfile from the parent project.