### PR TITLE
Iterate on stack name generation for bulk targeting `up` target

### DIFF
--- a/.changeset/long-penguins-greet.md
+++ b/.changeset/long-penguins-greet.md
@@ -1,0 +1,5 @@
+---
+'@wanews/nx-pulumi': minor
+---
+
+Introduce --env to trigger convention based stack name

--- a/libs/pulumi/README.md
+++ b/libs/pulumi/README.md
@@ -47,7 +47,7 @@ Default:
 ```
 nx affected --target=up --env=prod --all
 # Or in parallel
-
+nx affected --target=up --env=prod --all --parallel --maxParallel=5
 ```
 
 ### Running other pulumi commands

--- a/libs/pulumi/README.md
+++ b/libs/pulumi/README.md
@@ -22,13 +22,33 @@ This will start pulumi with a `--cwd` of the infrastructure project automaticall
 
 ### Affected deploys
 
-This module uses the `configuration` flag to calculate the stack name. By default it will use the format
+when using S3 or another state which doesn't include the project name in the state path, a good workaround is naming your stacks `<project-name>.<env>`. For example `my-project.prod`.
 
 ```
-[projectName].[configuration]
+[projectName].[env]
 ```
 
-For example if your `name` key in `Pulumi.yaml` is my-infrastructure and you pass `--configuration prod`, the stack name will be `my-infrastructure.prod`
+For example if your `name` key in `Pulumi.yaml` is my-infrastructure and you pass `--env prod`, the stack name will be `my-infrastructure.prod`
+
+This allows you to use the NX affected command with Pulumi to deploy all the affected stacks.
+
+#### Configuration
+
+Use the `configurationStackFormat` executor configuration value to change the stack name format.
+
+Current placeholders `[projectName]`, `[environment]`
+
+Default:
+
+`configurationStackFormat='[projectName].[environment]'`
+
+#### Example
+
+```
+nx affected --target=up --env=prod --all
+# Or in parallel
+
+```
 
 ### Running other pulumi commands
 

--- a/libs/pulumi/src/executors/up/executor.ts
+++ b/libs/pulumi/src/executors/up/executor.ts
@@ -13,13 +13,11 @@ export default async function runUpExecutor(
         throw new Error('No projectName')
     }
 
-    const infrastructureProject = options.infrastructureProject
-        ?? `${context.projectName}-infrastructure`
+    const infrastructureProject =
+        options.infrastructureProject ?? `${context.projectName}-infrastructure`
 
     const infrastructureRoot =
-        context.workspace.projects[
-            infrastructureProject
-        ].root
+        context.workspace.projects[infrastructureProject].root
 
     console.log(
         `> nx run ${options.targetProjectName}:${
@@ -69,31 +67,58 @@ export default async function runUpExecutor(
         }
     }
 
-    const pulumiArguments = process.argv.slice(4)
+    const commandLineMap: Record<string, string> = {
+        '--disableIntegrityChecking': '--disable-integrity-checking',
+        '--nonInteractive': '--non-interactive',
+        '--targetDependents': '--target-dependents',
+        '--targetReplace': '--target-replace',
+    }
+
+    let env: string | undefined
+
+    // NX Mangles command line args. Let's fix them back.
+    // https://github.com/nrwl/nx/issues/5710
+    // This is an incomplete list, should do all args
+    const pulumiArguments = process.argv
+        .slice(4)
+        .map((arg) => {
+            const mangled = Object.keys(commandLineMap).find((mangled) =>
+                arg.startsWith(mangled),
+            )
+            if (mangled) {
+                return arg.replace(mangled, commandLineMap[mangled])
+            }
+            return arg
+        })
+        .filter((arg) => {
+            if (arg.startsWith('--env')) {
+                env = arg.replace('--env=', '')
+                return false
+            }
+            if (arg.startsWith('--environment')) {
+                env = arg.replace('--environment=', '')
+                return false
+            }
+            return true
+        })
+
     const stackFormat =
-        options.configurationStackFormat || '[projectName].[configuration]'
+        options.configurationStackFormat || '[projectName].[environment]'
+    const pulumiProjectName: string = (
+        yaml.load(
+            fs
+                .readFileSync(path.join(infrastructureRoot, 'Pulumi.yaml'))
+                .toString(),
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ) as any
+    ).name
     const stackFromConfiguration =
-        context.configurationName && !pulumiArguments.includes('--stack')
+        env && !pulumiArguments.includes('--stack')
             ? [
                   '--stack',
                   stackFormat
-                      .replace(
-                          '[projectName]',
-                          (
-                              yaml.load(
-                                  fs
-                                      .readFileSync(
-                                          path.join(
-                                              infrastructureRoot,
-                                              'Pulumi.yaml',
-                                          ),
-                                      )
-                                      .toString(),
-                                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                              ) as any
-                          ).name,
-                      )
-                      .replace('[configuration]', context.configurationName),
+                      .replace('[projectName]', pulumiProjectName)
+                      .replace('[environment]', env),
               ]
             : []
     const pulumiArgs = [
@@ -103,6 +128,29 @@ export default async function runUpExecutor(
         ...pulumiArguments,
         ...stackFromConfiguration,
     ]
+
+    // Don't fail if using --env and that stack doesn't exist
+    if (env) {
+        if (
+            !fs.existsSync(
+                path.join(
+                    infrastructureRoot,
+                    `Pulumi.${pulumiProjectName}.${env}.yaml`,
+                ),
+            )
+        ) {
+            console.warn(
+                `${
+                    context.projectName || 'unknown project'
+                } skipped due to no stack configuration matching --env convention`,
+            )
+
+            return {
+                success: true,
+            }
+        }
+    }
+
     console.log(`> pulumi ${pulumiArgs.join(' ')}`)
     const pulumi = execa('pulumi', pulumiArgs, {
         stdio: [process.stdin, process.stdout, process.stderr],


### PR DESCRIPTION
See readme. But hopefully this will enable us to just go

`nx affected --target=up --env=prod --all`. It will then use the Pulumi project name and combine it with the --env flag to create the `--stack` argument