### PR TITLE
Breaking change: move `up` target to the infrastructure project

### DIFF
--- a/.changeset/good-parrots-glow.md
+++ b/.changeset/good-parrots-glow.md
@@ -1,0 +1,74 @@
+---
+'@wanews/nx-pulumi': minor
+---
+
+Breaking change: this module now adds the `up` target to the infrastructure project.
+
+Since the `up` target expects to be on the infrastructure project, existing projects may need to override the infrastructure project in `workspace.yaml`.
+
+For example, with the following `worspace.yaml` created with 0.12:
+
+```
+{
+  "version": 2,
+  "projects": {
+    "hello-world": {
+      "root": "apps/hello-world",
+      "projectType": "application",
+      "sourceRoot": "apps/hello-world/src",
+      "targets": {
+        "build": { ... },
+	"up": {
+          "executor": "@wanews/nx-pulumi:up",
+	  "options": {
+            "targetProjectName": "hello-world"
+	  }
+	}
+      }
+    },
+    "hello-world-infrastructure": {
+      "root": "apps/hello-world",
+      "projectType": "application",
+      "sourceRoot": "apps/hello-world/src",
+      "targets": {
+        "build": { ... }
+      }
+    }
+  }
+}
+```
+
+In 0.13+, the `up` target moves to the infrastructure project:
+
+```
+{
+  "version": 2,
+  "projects": {
+    "hello-world": {
+      "root": "apps/hello-world",
+      "projectType": "application",
+      "sourceRoot": "apps/hello-world/src",
+      "targets": {
+        "build": { ... }
+      }
+    },
+    "hello-world-infrastructure": {
+      "root": "apps/hello-world",
+      "projectType": "application",
+      "sourceRoot": "apps/hello-world/src",
+      "targets": {
+        "build": { ... },
+        "up": {
+          "executor": "@wanews/nx-pulumi:up",
+          "options": {
+            "targetProjectName": "hello-world"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+For convenience, the generator also adds a `deploy` target to the non-infrastructure project, which is an alias for the `up` target on the infrastructure project.
+

--- a/libs/pulumi/README.md
+++ b/libs/pulumi/README.md
@@ -12,13 +12,15 @@ nx g @wanews/nx-pulumi:init
 
 ### Running deploy
 
-@wanews/nx-pulumi will add a `up` target to the selected project.
+@wanews/nx-pulumi will add a `deploy` target to the selected project.
 
-`nx up <your-project-name>`
+`nx deploy <your-project-name>`
 
 This will start pulumi with a `--cwd` of the infrastructure project automatically. All arguments will be passed onto the pulumi CLI.
 
-`nx up my-app --stack dev`
+`nx deploy my-app --stack dev`
+
+Under the hood, this will run the `up` against your infrastructure project.
 
 ### Affected deploys
 

--- a/libs/pulumi/src/executors/up/executor.ts
+++ b/libs/pulumi/src/executors/up/executor.ts
@@ -14,7 +14,7 @@ export default async function runUpExecutor(
     }
 
     const infrastructureProject =
-        options.infrastructureProject ?? `${context.projectName}-infrastructure`
+        options.infrastructureProject ?? context.projectName
 
     const infrastructureRoot =
         context.workspace.projects[infrastructureProject]?.root
@@ -51,22 +51,20 @@ export default async function runUpExecutor(
         }
     }
 
-    for (const additionalBuildTarget of options.additionalBuildTargets || []) {
+    for (const buildTarget of options.buildTargets ??
+        options.additionalBuildTargets ??
+        []) {
         console.log(
-            `> nx run ${additionalBuildTarget.project}:${
-                additionalBuildTarget.target
-            }${
-                additionalBuildTarget.configuration
-                    ? `:${additionalBuildTarget.configuration}`
-                    : ''
+            `> nx run ${buildTarget.project}:${buildTarget.target}${
+                buildTarget.configuration ? `:${buildTarget.configuration}` : ''
             }`,
         )
         for await (const s of await runExecutor(
-            additionalBuildTarget,
+            buildTarget,
             {},
             {
                 ...context,
-                configurationName: additionalBuildTarget.configuration,
+                configurationName: buildTarget.configuration,
             },
         )) {
             if (!s.success) {

--- a/libs/pulumi/src/executors/up/schema.d.ts
+++ b/libs/pulumi/src/executors/up/schema.d.ts
@@ -7,5 +7,10 @@ export interface BuildExecutorSchema {
         target: string
         configuration?: string
     }>
+    buildTargets?: Array<{
+        project: string
+        target: string
+        configuration?: string
+    }>
     infrastructureProject?: string
 }

--- a/libs/pulumi/src/generators/init/generator.ts
+++ b/libs/pulumi/src/generators/init/generator.ts
@@ -80,7 +80,9 @@ function addFiles(host: Tree, options: PulumiGeneratorNormalizedSchema) {
 }
 
 export default async function (host: Tree, options: PulumiGeneratorSchema) {
+    // note to self: normalizedOptions represents the (new) infrastructure project
     const normalizedOptions = normalizeOptions(host, options)
+
     addProjectConfiguration(host, normalizedOptions.projectName, {
         root: normalizedOptions.projectRoot,
         projectType: 'application',
@@ -102,6 +104,12 @@ export default async function (host: Tree, options: PulumiGeneratorSchema) {
                 },
                 outputs: [`coverage/${normalizedOptions.projectRoot}`],
             },
+            up: {
+                executor: '@wanews/nx-pulumi:up',
+                options: {
+                    targetProjectName: normalizedOptions.targetProjectName,
+                },
+            },
         },
         tags: normalizedOptions.parsedTags,
         implicitDependencies: [normalizedOptions.targetProjectName],
@@ -112,10 +120,10 @@ export default async function (host: Tree, options: PulumiGeneratorSchema) {
         normalizedOptions.targetProjectName,
     )
     targetProjectConfig.targets = targetProjectConfig.targets || {}
-    targetProjectConfig.targets.up = {
-        executor: '@wanews/nx-pulumi:up',
+    targetProjectConfig.targets.deploy = {
+        executor: '@nrwl/workspace:run-commands',
         options: {
-            targetProjectName: normalizedOptions.targetProjectName,
+            commands: [`nx run ${normalizedOptions.projectName}:up`],
         },
     }
 
@@ -124,6 +132,7 @@ export default async function (host: Tree, options: PulumiGeneratorSchema) {
         normalizedOptions.targetProjectName,
         targetProjectConfig,
     )
+
     addFiles(host, normalizedOptions)
 
     if (host.exists('jest.config.js')) {


### PR DESCRIPTION
Breaking change: this module now adds the `up` target to the infrastructure project.

Since the `up` target expects to be on the infrastructure project, existing projects may need to override its infrastructure project in `workspace.yaml`, or move it to the infrastructure project.

This allows changes to the infrastructure project to be picked up by `nx affected`.

For example, with the following `worspace.yaml` created with 0.12:

```
{
  "version": 2,
  "projects": {
    "hello-world": {
      "root": "apps/hello-world",
      "projectType": "application",
      "sourceRoot": "apps/hello-world/src",
      "targets": {
        "build": { ... },
	"up": {
          "executor": "@wanews/nx-pulumi:up",
	  "options": {
            "targetProjectName": "hello-world"
	  }
	}
      }
    },
    "hello-world-infrastructure": {
      "root": "apps/hello-world",
      "projectType": "application",
      "sourceRoot": "apps/hello-world/src",
      "targets": {
        "build": { ... }
      }
    }
  }
}
```

In 0.13+, the `up` target moves to the infrastructure project:

```
{
  "version": 2,
  "projects": {
    "hello-world": {
      "root": "apps/hello-world",
      "projectType": "application",
      "sourceRoot": "apps/hello-world/src",
      "targets": {
        "build": { ... }
      }
    },
    "hello-world-infrastructure": {
      "root": "apps/hello-world",
      "projectType": "application",
      "sourceRoot": "apps/hello-world/src",
      "targets": {
        "build": { ... },
        "up": {
          "executor": "@wanews/nx-pulumi:up",
          "options": {
            "targetProjectName": "hello-world"
          }
        }
      }
    }
  }
}
```

For convenience, the generator also adds a `deploy` target to the non-infrastructure project, which is an alias for the `up` target on the infrastructure project.