### PR TITLE
Fixed destroy-stack generator failing when --yes is passed to arguments

### DIFF
--- a/.changeset/poor-trees-remember.md
+++ b/.changeset/poor-trees-remember.md
@@ -1,0 +1,5 @@
+---
+'@wanews/nx-pulumi': patch
+---
+
+Fixed destroy-stack generator failing when --yes is passed

--- a/libs/pulumi/src/generators/destroy-stack/generator.ts
+++ b/libs/pulumi/src/generators/destroy-stack/generator.ts
@@ -51,7 +51,8 @@ export default async function (
             'export',
             '--file',
             './state.json',
-            ...pulumiArguments,
+            // need to filter out --yes since export/import doesn't like it
+            ...pulumiArguments.filter((arg) => arg !== '--yes'),
         ]
         console.log(`> pulumi ${pulumiExportArgs.join(' ')}`)
         await execa('pulumi', pulumiExportArgs, {
@@ -63,7 +64,8 @@ export default async function (
             'import',
             '--file',
             './state.json',
-            ...pulumiArguments,
+            // need to filter out --yes since export/import doesn't like it
+            ...pulumiArguments.filter((arg) => arg !== '--yes'),
         ]
         console.log(`> pulumi ${pulumiImportArgs.join(' ')}`)
         await execa('pulumi', pulumiImportArgs, {


### PR DESCRIPTION

```
➜  nx generate @wanews/nx-pulumi:destroy-stack --projectName=my-app-infra --env=pr123 --removeStack --removeLock --removePendingOperations --refreshBeforeDestroy --non-interactive --yes
> pulumi stack export --file ./state.json --non-interactive --yes --stack my-app.pr123 --cwd apps/my-app-infra
Error: unknown flag: --yes
Usage:
  pulumi stack export [flags]

Flags:
      --file string          A filename to write stack output to
  -h, --help                 help for export
      --show-secrets false   Emit secrets in plaintext in exported stack. Defaults to false
      --version string       Previous stack version to export. (If unset, will export the latest.)

Global Flags:
      --color string                 Colorize output. Choices are: always, never, raw, auto (default "auto")
  -C, --cwd string                   Run pulumi as if it had been started in another directory
      --disable-integrity-checking   Disable integrity checking of checkpoint files
  -e, --emoji                        Enable emojis in the output (default true)
      --logflow                      Flow log settings to child processes (like plugins)
      --logtostderr                  Log to stderr instead of to files
      --non-interactive              Disable interactive mode for all commands
      --profiling string             Emit CPU and memory profiles and an execution trace to '[filename].[pid].{cpu,mem,trace}', respectively
  -s, --stack string                 The name of the stack to operate on. Defaults to the current stack
      --tracing file:                Emit tracing to the specified endpoint. Use the file: scheme to write tracing data to a local file
  -v, --verbose int                  Enable verbose logging (e.g., v=3); anything >3 is very verbose

An error occurred: unknown flag: --yes
Command failed with exit code 1: pulumi stack export --file ./state.json --non-interactive --yes --stack my-app.pr123 --cwd apps/my-app-infra
```