### PR TITLE
Fixed regression of --removePendingOperations in destroy-stack generator

### DIFF
--- a/.changeset/neat-boxes-hammer.md
+++ b/.changeset/neat-boxes-hammer.md
@@ -1,0 +1,5 @@
+---
+'@wanews/nx-pulumi': patch
+---
+
+Fixed regression in --removePendingOperations in destroy-stack generator caused by #51


### PR DESCRIPTION
This PR fixes 2 problems:
1. The `updateJson` and `tree.delete` were expecting the `state.json` to exist in the root of the workspace but pulumi puts it in the project's root.
2. Need to check if `pending_operations` is defined before filtering on it!