### PR TITLE
Fix broken typescript-project-references e2e test

### DIFF
--- a/apps/typescript-project-references-e2e/tests/typescript-project-references.spec.ts
+++ b/apps/typescript-project-references-e2e/tests/typescript-project-references.spec.ts
@@ -87,6 +87,14 @@ export function ${libName}(): string {
 }`,
         )
 
+        updateLibraryPackageJson(libName, (packageJson) => ({
+            ...packageJson,
+            dependencies: {
+                ...(packageJson.dependencies || {}),
+                [`@proj/${lib2Name}`]: '*',
+            },
+        }))
+
         // Run the test in app which asserts against the latest library source.
         await runNxCommandAsyncHandlingError(`test ${appName}`)
 
@@ -150,5 +158,19 @@ export function updateWorkspaceConfig(
     updateFile(
         'workspace.json',
         JSON.stringify(callback(readJson('workspace.json')), null, 2),
+    )
+}
+
+export function updateLibraryPackageJson(
+    libName: string,
+    callback: (json: { [key: string]: any }) => Object,
+) {
+    updateFile(
+        `libs/${libName}/package.json`,
+        JSON.stringify(
+            callback(readJson(`libs/${libName}/package.json`)),
+            null,
+            2,
+        ),
     )
 }


### PR DESCRIPTION
Error:
```
CLI Building entry: libs/lib8168610/src/index.ts
CLI Using tsconfig: tsconfig.json
CLI tsup v5.8.1
CLI Target: node12
ESM Build start
CJS Build start
 > libs/lib8168610/src/lib/lib8168610.ts:1:27: error: Could not resolve "@proj/lib9056948" (mark it as external to exclude it from the bundle)
    1 │ import { lib9056948 } from '@proj/lib9056948'
      ╵                            ~~~~~~~~~~~~~~~~~~

 > libs/lib8168610/src/lib/lib8168610.ts:1:27: error: Could not resolve "@proj/lib9056948" (mark it as external to exclude it from the bundle)
    1 │ import { lib9056948 } from '@proj/lib9056948'
      ╵                            ~~~~~~~~~~~~~~~~~~

CJS Build failed
Error: Build failed with 1 error:
libs/lib8168610/src/lib/lib8168610.ts:1:27: error: Could not resolve "@proj/lib9056948" (mark it as external to exclude it from the bundle)
ESM Build failed
```

The `package.json` needs to include lib dependencies otherwise the `--external` options to `tsup` won't be passed. See https://github.com/sevenwestmedia-labs/nx-plugins/blob/main/libs/typescript-project-references/src/executors/package/executor.ts#L49