### PR TITLE
fix(esbuild-build-executor): external cannot be emptied

### DIFF
--- a/libs/nx-esbuild/src/executors/build/executor.ts
+++ b/libs/nx-esbuild/src/executors/build/executor.ts
@@ -32,12 +32,11 @@ export default async function runExecutor(
         sourcemap: true,
         logLevel: 'info',
         metafile: true,
-        ...options,
         external: [
-            ...(options.external || []),
             ...Object.keys(packageJson?.dependencies || {}),
             ...Object.keys(packageJson?.devDependencies || {}),
         ],
+        ...options,
         plugins: options.plugins?.map((plugin) => {
             // eslint-disable-next-line @typescript-eslint/no-var-requires
             const pluginPkg = require(plugin.package)


### PR DESCRIPTION
Currently, the executor is automatically marking all the **deps** and **devDeps** as `external`.

This is a nice feature but in my case I would like my bundle to inline all the imported dependencies (ie. no external).

This PR makes sure that the user's options are always taken last and allows `external: []` to override the executor default behavior.