### PR TITLE
fix(generators): wrong required field name

### DIFF
--- a/libs/pulumi/src/generators/create-stack/schema.json
+++ b/libs/pulumi/src/generators/create-stack/schema.json
@@ -34,6 +34,6 @@
     },
     "required": [
         "projectName",
-        "env"
+        "environment"
     ]
 }

--- a/libs/pulumi/src/generators/destroy-stack/schema.json
+++ b/libs/pulumi/src/generators/destroy-stack/schema.json
@@ -53,6 +53,6 @@
     },
     "required": [
         "projectName",
-        "env"
+        "environment"
     ]
 }

--- a/libs/pulumi/src/generators/restore-config/schema.json
+++ b/libs/pulumi/src/generators/restore-config/schema.json
@@ -31,6 +31,6 @@
     },
     "required": [
         "projectName",
-        "env"
+        "environment"
     ]
 }


### PR DESCRIPTION
Hello,

Here a small fix to specify the correct field name for `required`.
`env` is the alias of `environment` field.