### PR TITLE
fix: add cwd arg on pulumi command for destroy generator

### DIFF
--- a/.changeset/six-crabs-whisper.md
+++ b/.changeset/six-crabs-whisper.md
@@ -1,0 +1,5 @@
+---
+"@wanews/nx-pulumi": patch
+---
+
+fix: add cwd arg on pulumi command for destroy generator

--- a/libs/pulumi/src/generators/destroy-stack/generator.ts
+++ b/libs/pulumi/src/generators/destroy-stack/generator.ts
@@ -3,6 +3,7 @@ import { readProjectConfiguration, Tree, updateJson } from '@nrwl/devkit'
 import execa from 'execa'
 import path from 'path'
 import { getStackInfo } from '../../helpers/get-pulumi-args'
+import { execPulumi } from '../../helpers/exec-pulumi';
 import { CreateStackGeneratorSchema } from './schema'
 
 const s3 = new S3({})
@@ -55,10 +56,7 @@ export default async function (
             '--file',
             path.basename(stateFile),
         ]
-        console.log(`> pulumi ${pulumiExportArgs.join(' ')}`)
-        await execa('pulumi', pulumiExportArgs, {
-            stdio: [process.stdin, process.stdout, process.stderr],
-        })
+        await execPulumi(pulumiExportArgs);
 
         // remove the pending operations from the state
         updateJson(tree, stateFile, (state) => {
@@ -86,15 +84,12 @@ export default async function (
         const pulumiImportArgs = [
             'stack',
             'import',
-            '--stack',
-            stack,
+            '--stack', stack,
+            '--cwd', targetProjectConfig.root,
             '--file',
             path.basename(stateFile),
         ]
-        console.log(`> pulumi ${pulumiImportArgs.join(' ')}`)
-        await execa('pulumi', pulumiImportArgs, {
-            stdio: [process.stdin, process.stdout, process.stderr],
-        })
+        await execPulumi(pulumiImportArgs);
 
         tree.delete(stateFile)
     }
@@ -102,39 +97,35 @@ export default async function (
     if (options.refreshBeforeDestroy) {
         const pulumiRefreshArgs = [
             'refresh',
-            '--stack',
-            stack,
+            '--stack', stack,
+            '--cwd', targetProjectConfig.root,
             ...(options.target
                 ? options.target.map((target) => `--target=${target}`)
                 : []),
         ]
-        console.log(`> pulumi ${pulumiRefreshArgs.join(' ')}`)
-        await execa('pulumi', pulumiRefreshArgs, {
-            stdio: [process.stdin, process.stdout, process.stderr],
-        })
+        await execPulumi(pulumiRefreshArgs);
     }
 
     // delete the resources in the stack
     const pulumiDestroyArgs = [
         'destroy',
-        '--stack',
-        stack,
+        '--stack', stack,
+        '--cwd', targetProjectConfig.root,
         ...(options.target
             ? options.target.map((target) => `--target=${target}`)
             : []),
     ]
-    console.log(`> pulumi ${pulumiDestroyArgs.join(' ')}`)
-    await execa('pulumi', pulumiDestroyArgs, {
-        stdio: [process.stdin, process.stdout, process.stderr],
-    })
+    await execPulumi(pulumiDestroyArgs);
 
     if (options.removeStack) {
         // remove the stack
-        const pulumiRemoveArgs = ['stack', 'rm', '--stack', stack]
-        console.log(`> pulumi ${pulumiRemoveArgs.join(' ')}`)
-        await execa('pulumi', pulumiRemoveArgs, {
-            stdio: [process.stdin, process.stdout, process.stderr],
-        })
+        const pulumiRemoveArgs = [
+            'stack', 
+            'rm', 
+            '--stack', stack,
+            '--cwd', targetProjectConfig.root,
+        ]
+        await execPulumi(pulumiRemoveArgs);
 
         // remove the config
         if (backendUrl && backendUrl.startsWith('s3://')) {

--- a/libs/pulumi/src/generators/destroy-stack/generator.ts
+++ b/libs/pulumi/src/generators/destroy-stack/generator.ts
@@ -1,6 +1,5 @@
 import { S3 } from '@aws-sdk/client-s3'
 import { readProjectConfiguration, Tree, updateJson } from '@nrwl/devkit'
-import execa from 'execa'
 import path from 'path'
 import { getStackInfo } from '../../helpers/get-pulumi-args'
 import { execPulumi } from '../../helpers/exec-pulumi';

--- a/libs/pulumi/src/generators/destroy-stack/generator.ts
+++ b/libs/pulumi/src/generators/destroy-stack/generator.ts
@@ -47,7 +47,7 @@ export default async function (
     if (options.removePendingOperations) {
         const stateFile = `${targetProjectConfig.root}/${stack}-state.json`
 
-        const pulumiExportArgs = [
+        const pulumiExportArgs: string[] = [
             'stack',
             'export',
             '--stack',
@@ -80,7 +80,7 @@ export default async function (
             return state
         })
 
-        const pulumiImportArgs = [
+        const pulumiImportArgs: string[] = [
             'stack',
             'import',
             '--stack', stack,
@@ -94,7 +94,7 @@ export default async function (
     }
 
     if (options.refreshBeforeDestroy) {
-        const pulumiRefreshArgs = [
+        const pulumiRefreshArgs: string[] = [
             'refresh',
             '--stack', stack,
             '--cwd', targetProjectConfig.root,
@@ -106,7 +106,7 @@ export default async function (
     }
 
     // delete the resources in the stack
-    const pulumiDestroyArgs = [
+    const pulumiDestroyArgs: string[] = [
         'destroy',
         '--stack', stack,
         '--cwd', targetProjectConfig.root,
@@ -118,7 +118,7 @@ export default async function (
 
     if (options.removeStack) {
         // remove the stack
-        const pulumiRemoveArgs = [
+        const pulumiRemoveArgs: string[] = [
             'stack', 
             'rm', 
             '--stack', stack,

--- a/libs/pulumi/src/generators/init-standalone/files/tsconfig.json__template__
+++ b/libs/pulumi/src/generators/init-standalone/files/tsconfig.json__template__
@@ -1,5 +1,5 @@
 {
-  "extends": "<%= offsetFromRoot %>tsconfig.settings.json",
+  "extends": "<%= offsetFromRoot %>tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./bin",
     "rootDir": "./src",

--- a/libs/pulumi/src/generators/init/files/tsconfig.json__template__
+++ b/libs/pulumi/src/generators/init/files/tsconfig.json__template__
@@ -1,5 +1,5 @@
 {
-  "extends": "<%= offsetFromRoot %>tsconfig.settings.json",
+  "extends": "<%= offsetFromRoot %>tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./bin",
     "rootDir": "./src",

--- a/libs/pulumi/src/helpers/exec-pulumi.ts
+++ b/libs/pulumi/src/helpers/exec-pulumi.ts
@@ -1,6 +1,6 @@
 import execa from 'execa'
 
-export async function execPulumi(...pulumiArgs: string[]) {
+export async function execPulumi(pulumiArgs: string[]) {
     console.log(`> pulumi ${pulumiArgs.join(' ')}`)
     await execa('pulumi', pulumiArgs, {
         stdio: [process.stdin, process.stdout, process.stderr],

--- a/libs/pulumi/src/helpers/exec-pulumi.ts
+++ b/libs/pulumi/src/helpers/exec-pulumi.ts
@@ -1,0 +1,9 @@
+import execa from 'execa'
+
+async function execPulumi(pulumiArgs: string[]) {
+    console.log(`> pulumi ${pulumiArgs.join(' ')}`)
+    await execa('pulumi', pulumiArgs, {
+        stdio: [process.stdin, process.stdout, process.stderr],
+    })
+}
+

--- a/libs/pulumi/src/helpers/exec-pulumi.ts
+++ b/libs/pulumi/src/helpers/exec-pulumi.ts
@@ -1,6 +1,6 @@
 import execa from 'execa'
 
-async function execPulumi(pulumiArgs: string[]) {
+export async function execPulumi(...pulumiArgs: string[]) {
     console.log(`> pulumi ${pulumiArgs.join(' ')}`)
     await execa('pulumi', pulumiArgs, {
         stdio: [process.stdin, process.stdout, process.stderr],


### PR DESCRIPTION
Destroy generator doesn't works because  `cwd` arg is not present.

Here the fix and a small refactor