### PR TITLE
Fix readme commands

### DIFF
--- a/.changeset/thick-students-pretend.md
+++ b/.changeset/thick-students-pretend.md
@@ -1,0 +1,5 @@
+---
+"@wanews/nx-pulumi": patch
+---
+
+Fix readme commands

--- a/libs/pulumi/README.md
+++ b/libs/pulumi/README.md
@@ -13,7 +13,7 @@ nx g @wanews/nx-pulumi:init
 ### create-stack
 
 ```
-nx @wanews/nx-pulumi:create-stack --projectName=my-app-infrastructure --env=dev
+nx g @wanews/nx-pulumi:create-stack --projectName=my-app-infrastructure --env=dev
 ```
 
 #### env
@@ -25,7 +25,7 @@ Will create the stack name by prefixing the pulumi project name. ie `--env=prod`
 ### destroy-stack
 
 ```
-nx wanews/nx-pulumi:destroy-stack --projectName=my-app-infrastructure --env=dev
+nx g @wanews/nx-pulumi:destroy-stack --projectName=my-app-infrastructure --env=dev
 ```
 
 #### env
@@ -39,7 +39,7 @@ Will create the stack name by prefixing the pulumi project name. ie `--env=prod`
 Config files have the secret provider hashes so as an alternative to checking them into git you can use this command to put the config files into s3, then optionally restore them before doing an up
 
 ```
-nx wanews/nx-pulumi:backup-config --projectName=my-app-infrastructure --env=dev
+nx g @wanews/nx-pulumi:backup-config --projectName=my-app-infrastructure --env=dev
 ```
 
 ### config-restore
@@ -47,7 +47,7 @@ nx wanews/nx-pulumi:backup-config --projectName=my-app-infrastructure --env=dev
 Config files have the secret provider hashes so as an alternative to checking them into git you can use this command to put the config files into s3, then optionally restore them before doing an up
 
 ```
-nx wanews/nx-pulumi:restore-config --projectName=my-app-infrastructure --env=dev
+nx g @wanews/nx-pulumi:restore-config --projectName=my-app-infrastructure --env=dev
 ```
 
 ## Executors


### PR DESCRIPTION
A couple more things I'd like to include but don't know how:

1. Add an `up` target when using `init-standalone`
2. Create a `Pulumi.<stack>.yaml` file as part of `create-stack`
3. remove root from tsconfig.json so that other projects in the root `tsconfig.json::compilerOptions.paths` can be used