### PR TITLE
Fix test command path in nx-pulumi init template

### DIFF
--- a/.changeset/violet-sloths-accept.md
+++ b/.changeset/violet-sloths-accept.md
@@ -1,0 +1,5 @@
+---
+'@wanews/nx-pulumi': patch
+---
+
+Fix test command path in generate init template

--- a/apps/pulumi-e2e/tests/pulumi.spec.ts
+++ b/apps/pulumi-e2e/tests/pulumi.spec.ts
@@ -3,7 +3,7 @@ import {
     patchPackageJsonForPlugin,
     readJson,
     runCommandAsync,
-    uniq,
+    uniq
 } from '@nrwl/nx-plugin/testing'
 import { describe, expect, it } from 'vitest'
 
@@ -53,7 +53,7 @@ describe('init e2e', () => {
                     executor: '@nrwl/workspace:run-commands',
                     options: {
                         command: 'npx vitest --run',
-                        cwd: `libs/apps/${app}-infrastructure`,
+                        cwd: `apps/${app}-infrastructure`,
                     },
                 },
                 up: {

--- a/libs/pulumi/src/generators/init/generator.ts
+++ b/libs/pulumi/src/generators/init/generator.ts
@@ -101,7 +101,7 @@ export default async function (host: Tree, options: PulumiGeneratorSchema) {
                 executor: '@nrwl/workspace:run-commands',
                 options: {
                     command: 'npx vitest --run',
-                    cwd: `libs/${normalizedOptions.projectRoot}`,
+                    cwd: `${normalizedOptions.projectRoot}`,
                 },
             },
             up: {


### PR DESCRIPTION
The generated pulumi project is added to `apps/` path. The test command for the generated project should also use the same path.

# Reproducing

1. Generate new project with the `nx generate @wanews/nx-pulumi:init`
2. Run the tests => test fails (due to current working directory is invalid)