### PR TITLE
Add skip preview configuration to Pulumi up executor

### DIFF
--- a/.changeset/popular-shirts-return.md
+++ b/.changeset/popular-shirts-return.md
@@ -1,0 +1,5 @@
+---
+'@wanews/nx-pulumi': minor
+---
+
+Add skip preview configuration to Pulumi up executor

--- a/libs/pulumi/src/executors/up/executor.ts
+++ b/libs/pulumi/src/executors/up/executor.ts
@@ -71,6 +71,7 @@ export default async function runUpExecutor(
         ...(options.yes ? ['--yes'] : []),
         '--stack',
         stack,
+        ...(options.skipPreview ? ['--skip-preview'] : []),
         ...(options.nonInteractive ? ['--non-interactive'] : []),
         ...(options.secretsProvider
             ? ['--secrets-provider', options.secretsProvider]

--- a/libs/pulumi/src/executors/up/schema.d.ts
+++ b/libs/pulumi/src/executors/up/schema.d.ts
@@ -7,6 +7,7 @@ export interface BuildExecutorSchema {
     }>
     yes?: boolean
     disableIntegrityChecking?: boolean
+    skipPreview?: boolean
     nonInteractive?: boolean
     secretsProvider?: string
     environment?: string

--- a/libs/pulumi/src/executors/up/schema.json
+++ b/libs/pulumi/src/executors/up/schema.json
@@ -47,6 +47,9 @@
         "disableIntegrityChecking": {
             "type": "boolean"
         },
+        "skipPreview": {
+            "type": "boolean"
+        },
         "nonInteractive": {
             "type": "boolean"
         },


### PR DESCRIPTION
Running Pulumi up command's preview in CICD can be unnecessary and just takes significantly extra time. Allow configuring the executor to use `--skip-preview` flag for the Pulumi cli.