### PR TITLE
Add yes and skipPreview flags to Pulumi destroy-stack generator

### DIFF
--- a/.changeset/sour-deers-vanish.md
+++ b/.changeset/sour-deers-vanish.md
@@ -1,0 +1,5 @@
+---
+'@wanews/nx-pulumi': minor
+---
+
+Add yes and skipPreview flags to Pulumi destroy-stack generator

--- a/libs/pulumi/src/generators/destroy-stack/generator.ts
+++ b/libs/pulumi/src/generators/destroy-stack/generator.ts
@@ -3,13 +3,13 @@ import { readProjectConfiguration, Tree, updateJson } from '@nrwl/devkit'
 import path from 'path'
 import { getStackInfo } from '../../helpers/get-pulumi-args'
 import { execPulumi } from '../../helpers/exec-pulumi';
-import { CreateStackGeneratorSchema } from './schema'
+import { DestroyStackGeneratorSchema } from './schema'
 
 const s3 = new S3({})
 
 export default async function (
     tree: Tree,
-    options: CreateStackGeneratorSchema,
+    options: DestroyStackGeneratorSchema,
 ) {
     if (!options.projectName) {
         throw new Error('No projectName')

--- a/libs/pulumi/src/generators/destroy-stack/generator.ts
+++ b/libs/pulumi/src/generators/destroy-stack/generator.ts
@@ -113,16 +113,19 @@ export default async function (
         ...(options.target
             ? options.target.map((target) => `--target=${target}`)
             : []),
+        ...(options.yes ? ['--yes'] : []),
+        ...(options.skipPreview ? ['--skip-preview'] : []),
     ]
     await execPulumi(pulumiDestroyArgs);
 
     if (options.removeStack) {
         // remove the stack
         const pulumiRemoveArgs: string[] = [
-            'stack', 
-            'rm', 
+            'stack',
+            'rm',
             '--stack', stack,
             '--cwd', targetProjectConfig.root,
+            ...(options.yes ? ['--yes'] : []),
         ]
         await execPulumi(pulumiRemoveArgs);
 

--- a/libs/pulumi/src/generators/destroy-stack/schema.d.ts
+++ b/libs/pulumi/src/generators/destroy-stack/schema.d.ts
@@ -6,6 +6,8 @@ export interface DestroyStackGeneratorSchema {
 
     target?: string[]
 
+    yes?: boolean
+    skipPreview?: boolean
     ignorePendingCreateOperations?: boolean
     removeLock?: boolean
     removeStack?: boolean

--- a/libs/pulumi/src/generators/destroy-stack/schema.d.ts
+++ b/libs/pulumi/src/generators/destroy-stack/schema.d.ts
@@ -1,4 +1,4 @@
-export interface CreateStackGeneratorSchema {
+export interface DestroyStackGeneratorSchema {
     projectName: string
     environment?: string
     stack?: string

--- a/libs/pulumi/src/generators/destroy-stack/schema.json
+++ b/libs/pulumi/src/generators/destroy-stack/schema.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/schema",
     "cli": "nx",
-    "$id": "CreateStack",
+    "$id": "DestroyStack",
     "title": "",
     "type": "object",
     "properties": {

--- a/libs/pulumi/src/generators/destroy-stack/schema.json
+++ b/libs/pulumi/src/generators/destroy-stack/schema.json
@@ -28,6 +28,12 @@
         "configurationStackFormat": {
             "type": "string"
         },
+        "yes": {
+            "type": "boolean"
+        },
+        "skipPreview": {
+            "type": "boolean"
+        },
         "ignorePendingCreateOperations": {
             "type": "boolean"
         },


### PR DESCRIPTION
"yes" and "skipPreview" flags allow running the deploy-stack generator in CICD in efficient manner.

Included couple formatting / naming related refactorings in the PR.