### PR TITLE
Show error messages when serving

### DIFF
--- a/libs/nx-esbuild/src/executors/serve/executor.ts
+++ b/libs/nx-esbuild/src/executors/serve/executor.ts
@@ -71,7 +71,7 @@ export default async function runExecutor(
 
     const serveProcess = customServeCommand
         ? execa.command(customServeCommand, {
-            stdio: [process.stdin, process.stdout, 'pipe'],
+            stdio: [process.stdin, process.stdout, process.stderr, 'pipe'],
             cwd: customServeCommandCwd,
         })
         : execa(
@@ -86,7 +86,7 @@ export default async function runExecutor(
                 options.outfile!,
             ],
             {
-                stdio: [process.stdin, process.stdout, 'pipe'],
+                stdio: [process.stdin, process.stdout, process.stderr, 'pipe'],
             },
         )
     await serveProcess


### PR DESCRIPTION
Currently errors are swallowed, only showing "[nodemon] app crashed - waiting for file changes before starting..." -- maybe there's a better way, but this allows the dev to see the issue