### PR TITLE
make `--open` option configurable for nx-vite:serve executor

### DIFF
--- a/libs/nx-vite/src/executors/serve/executor.ts
+++ b/libs/nx-vite/src/executors/serve/executor.ts
@@ -12,10 +12,15 @@ export default async function runExecutor(
     }
     const packageManager = getPackageManagerCommand()
     const appRoot = context.workspace.projects[context.projectName].root
+    const args: string[] = [];
+
+    if (_options.open) {
+        args.push('--open');
+    }
 
     const vite = execa(
         packageManager.exec,
-        ['vite', `${context.cwd}/${appRoot}`, '--open'],
+        ['vite', `${context.cwd}/${appRoot}`, ...args],
         {
             stdio: [process.stdin, process.stdout, 'pipe'],
         },

--- a/libs/nx-vite/src/executors/serve/schema.d.ts
+++ b/libs/nx-vite/src/executors/serve/schema.d.ts
@@ -1,2 +1,4 @@
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface ServeExecutorSchema {}
+export interface ServeExecutorSchema {
+    open?: boolean
+}

--- a/libs/nx-vite/src/executors/serve/schema.json
+++ b/libs/nx-vite/src/executors/serve/schema.json
@@ -1,6 +1,12 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "properties": {},
+    "properties": {
+        "open": {
+            "type": "boolean",
+            "default": false,
+            "description": "Automatically open the app in the browser on server start."
+        }
+    },
     "type": "object",
     "cli": "nx",
     "title": "Vite Serve Executor"

--- a/libs/nx-vite/src/generators/react/generator.ts
+++ b/libs/nx-vite/src/generators/react/generator.ts
@@ -65,7 +65,9 @@ export default async function (host: Tree, options: NodeGeneratorSchema) {
         targets: {
             build: {
                 executor: '@wanews/nx-vite:build',
-                options: {},
+                options: {
+                    open: true,
+                },
             },
             serve: {
                 executor: '@wanews/nx-vite:serve',


### PR DESCRIPTION
Turned vite `--open` parameter to be configurable. By default it's turned off, but I kept it on in react generator to keep the same behavior.