### PR TITLE
Feat/pass env vars to pulumi up executor

### DIFF
--- a/.changeset/violet-suns-juggle.md
+++ b/.changeset/violet-suns-juggle.md
@@ -1,0 +1,5 @@
+---
+'@wanews/nx-pulumi': minor
+---
+
+Allow passing in Environment Variables by `--envVars=` arguement

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Install pnpm
         run: |
-          npm i -g pnpm
+          npm i -g pnpm@6
           pnpm set verify-store-integrity false
 
       - name: pnpm install

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Install pnpm
         run: |
-          npm i -g pnpm
+          npm i -g pnpm@6
           pnpm set verify-store-integrity false
       - name: pnpm install
         run: |

--- a/libs/pulumi/README.md
+++ b/libs/pulumi/README.md
@@ -66,6 +66,14 @@ nx up my-app-infrastructure --stack dev
 
 Will create the stack name by prefixing the pulumi project name. ie `--env=prod` is the same as `--stack=<projectname>.prod`.
 
+#### Environment Variables
+
+`--envVars="KEY=value`
+
+Passes through a comma-seperated list of environment variables to the pulumi command
+
+For example, if you need to build docker images built by pulumi to target a specific architechure CPU architechure (eg `linux/amd64`), you can the add arguement `--envVars="DOCKER_DEFAULT_PLATFORM=linux/amd64"`
+
 ## Running deploy
 
 @wanews/nx-pulumi will add a `deploy` target to the selected project. This will start pulumi with a `--cwd` of the infrastructure project automatically

--- a/libs/pulumi/src/executors/up/executor.ts
+++ b/libs/pulumi/src/executors/up/executor.ts
@@ -64,6 +64,15 @@ export default async function runUpExecutor(
         }
     }
 
+    const envObject: {
+        [key: string]: string
+    } = {}
+
+    options.envVars?.forEach((envVar) => {
+        const [key, value] = envVar.split('=')
+        envObject[key] = value
+    })
+
     const pulumiArgs = [
         'up',
         '--cwd',
@@ -83,8 +92,10 @@ export default async function runUpExecutor(
     ]
 
     console.log(`> pulumi ${pulumiArgs.join(' ')}`)
+    console.log(`${options.envVars}`)
     const pulumi = execa('pulumi', pulumiArgs, {
         stdio: [process.stdin, process.stdout, process.stderr],
+        env: envObject,
     })
     try {
         const res = await pulumi

--- a/libs/pulumi/src/executors/up/schema.d.ts
+++ b/libs/pulumi/src/executors/up/schema.d.ts
@@ -13,4 +13,5 @@ export interface UpExecutorSchema {
     environment?: string
     stack?: string
     refresh?: boolean
+    envVars?: string[]
 }

--- a/libs/pulumi/src/executors/up/schema.json
+++ b/libs/pulumi/src/executors/up/schema.json
@@ -12,9 +12,7 @@
         "environment": {
             "description": "",
             "type": "string",
-            "aliases": [
-                "env"
-            ]
+            "aliases": ["env"]
         },
         "stack": {
             "description": "Pulumi stack name",
@@ -35,10 +33,7 @@
                         "type": "string"
                     }
                 },
-                "required": [
-                    "project",
-                    "target"
-                ]
+                "required": ["project", "target"]
             }
         },
         "configurationStackFormat": {
@@ -58,6 +53,13 @@
         },
         "refresh": {
             "type": "boolean"
+        },
+        "envVars": {
+            "description": "Array of Environment Variables",
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
         }
     }
 }


### PR DESCRIPTION
Allow passing in a comma-seperated list of environment variables via the arguement `--envVars=` to the pulumi up executor