### PR TITLE
[nx/pulumi] Hide undefinded log when envVars are not defined

### DIFF
--- a/.changeset/happy-houses-allow.md
+++ b/.changeset/happy-houses-allow.md
@@ -1,0 +1,5 @@
+---
+'@wanews/nx-pulumi': minor
+---
+
+Hide undefinded log when the env vars are not defined

--- a/libs/pulumi/src/executors/up/executor.ts
+++ b/libs/pulumi/src/executors/up/executor.ts
@@ -92,7 +92,10 @@ export default async function runUpExecutor(
     ]
 
     console.log(`> pulumi ${pulumiArgs.join(' ')}`)
-    console.log(`${options.envVars}`)
+    if (options.envVars) {
+        console.log(`${options.envVars}`)
+    }
+
     const pulumi = execa('pulumi', pulumiArgs, {
         stdio: [process.stdin, process.stdout, process.stderr],
         env: envObject,


### PR DESCRIPTION
Hello 👋
Sorry for this simple PR, but i really hate the `undefined` log everytime that I run the `up` command. 
Example:
![image](https://github.com/sevenwestmedia-labs/nx-plugins/assets/2272323/a2a4b3c3-6e8b-4372-87dd-72b9079a7fd1)
