### PR TITLE
FIX: Update the executors to utilise the Modern Context

### DIFF
--- a/.changeset/tall-jokes-bake.md
+++ b/.changeset/tall-jokes-bake.md
@@ -1,0 +1,8 @@
+---
+'@wanews/nx-typescript-project-references': minor
+'@wanews/nx-esbuild': minor
+'@wanews/nx-vite': minor
+'@wanews/nx-pulumi': minor
+---
+
+Fixed usage of the deprecated context.workspace in the executors, and now utilise the context.projectsConfigurations

--- a/libs/nx-esbuild/src/executors/build/executor.ts
+++ b/libs/nx-esbuild/src/executors/build/executor.ts
@@ -10,7 +10,8 @@ export default async function runExecutor(
     if (!context.projectName) {
         throw new Error('No projectName')
     }
-    const appRoot = context.workspace?.projects[context.projectName].root
+    const appRoot =
+        context.projectsConfigurations?.projects[context.projectName].root
 
     const packageJson = fs.existsSync(`${appRoot}/package.json`)
         ? JSON.parse(fs.readFileSync(`${appRoot}/package.json`).toString())

--- a/libs/nx-esbuild/src/executors/package/executor.ts
+++ b/libs/nx-esbuild/src/executors/package/executor.ts
@@ -14,7 +14,8 @@ export default async function runExecutor(
         throw new Error('No projectName')
     }
     const packageManager = detectPackageManager()
-    const appRoot = context.workspace?.projects[context.projectName].root
+    const appRoot =
+        context.projectsConfigurations?.projects[context.projectName].root
     const workspaceRoot = context.root
 
     if (appRoot === undefined) {

--- a/libs/nx-esbuild/src/executors/serve/executor.ts
+++ b/libs/nx-esbuild/src/executors/serve/executor.ts
@@ -33,7 +33,8 @@ export default async function runExecutor(
             : packageManager === 'yarn'
             ? 'yarn'
             : 'npx'
-    const appRoot = context.workspace?.projects[context.projectName].root
+    const appRoot =
+        context.projectsConfigurations?.projects[context.projectName].root
 
     const packageJson = fs.existsSync(`${appRoot}/package.json`)
         ? JSON.parse(fs.readFileSync(`${appRoot}/package.json`).toString())

--- a/libs/nx-vite/src/executors/build/executor.ts
+++ b/libs/nx-vite/src/executors/build/executor.ts
@@ -11,7 +11,8 @@ export default async function runExecutor(
         throw new Error('No projectName')
     }
 
-    const appRoot = context.workspace?.projects[context.projectName].root
+    const appRoot =
+        context.projectsConfigurations?.projects[context.projectName].root
 
     const buildConfig: InlineConfig = {
         root: context.cwd + '/' + appRoot,

--- a/libs/nx-vite/src/executors/serve/executor.ts
+++ b/libs/nx-vite/src/executors/serve/executor.ts
@@ -11,7 +11,8 @@ export default async function runExecutor(
         throw new Error('No projectName')
     }
     const packageManager = getPackageManagerCommand()
-    const appRoot = context.workspace?.projects[context.projectName].root
+    const appRoot =
+        context.projectsConfigurations?.projects[context.projectName].root
 
     const vite = execa(
         packageManager.exec,

--- a/libs/pulumi/src/executors/destroy/executor.ts
+++ b/libs/pulumi/src/executors/destroy/executor.ts
@@ -13,7 +13,7 @@ export default async function runUpExecutor(
     }
 
     const infrastructureRoot =
-        context.workspace?.projects[context.projectName]?.root
+        context.projectsConfigurations?.projects[context.projectName]?.root
 
     if (!infrastructureRoot) {
         console.error(`Error: Cannot find root for ${context.projectName}.`)

--- a/libs/pulumi/src/executors/refresh/executor.ts
+++ b/libs/pulumi/src/executors/refresh/executor.ts
@@ -13,7 +13,7 @@ export default async function runUpExecutor(
     }
 
     const infrastructureRoot =
-        context.workspace?.projects[context.projectName]?.root
+        context.projectsConfigurations?.projects[context.projectName]?.root
 
     if (!infrastructureRoot) {
         console.error(`Error: Cannot find root for ${context.projectName}.`)

--- a/libs/pulumi/src/executors/up/executor.ts
+++ b/libs/pulumi/src/executors/up/executor.ts
@@ -13,7 +13,7 @@ export default async function runUpExecutor(
     }
 
     const infrastructureRoot =
-        context.workspace?.projects[context.projectName]?.root
+        context.projectsConfigurations?.projects[context.projectName]?.root
 
     if (!infrastructureRoot) {
         console.error(`Error: Cannot find root for ${context.projectName}.`)

--- a/libs/typescript-project-references/src/executors/package/executor.ts
+++ b/libs/typescript-project-references/src/executors/package/executor.ts
@@ -27,7 +27,8 @@ export async function packageExecutor(
             ? 'yarn'
             : 'npx'
     const projGraph = await createProjectGraphAsync()
-    const libRoot = context.workspace?.projects[context.projectName].root
+    const libRoot =
+        context.projectsConfigurations?.projects[context.projectName].root
     const { target, dependencies } = calculateProjectDependencies(
         projGraph,
         context.root,


### PR DESCRIPTION
## What

typescript-project-references is unable to find the context.workspace on the latest version of NX (19.2.2)

## How

Updated to remove the deprecated variable and utilise context.projectsConfigurations instead